### PR TITLE
Feat/expandwl

### DIFF
--- a/crawlerService/baseUrls.json
+++ b/crawlerService/baseUrls.json
@@ -359,7 +359,6 @@
   "blog.wearewizards.io": true,
   "blogs.dropbox.com": true,
   "blogs.janestreet.com": true,
-  "blogs.msdn.microsoft.com": false,
   "blogs.windows.com": true,
   "brendaneich.com": true,
   "clusterhq.com": true,

--- a/crawlerService/childProc.js
+++ b/crawlerService/childProc.js
@@ -6,7 +6,7 @@ console.log('Firing up process ', process.pid);
 var masterMessageHandler = (message) => {
   if (message.type === 'start') {
     var count = message.count;
-    crawlUrl(message.data, (links) => {
+    crawlUrl(message.data, null, (links) => {
       process.send({
         type: 'finish',
         from: cluster.worker.id,

--- a/crawlerService/childProc.js
+++ b/crawlerService/childProc.js
@@ -6,7 +6,7 @@ console.log('Firing up process ', process.pid);
 var masterMessageHandler = (message) => {
   if (message.type === 'start') {
     var count = message.count;
-    crawlUrl(message.data, null, (links) => {
+    crawlUrl(message.data, message.options, (links) => {
       process.send({
         type: 'finish',
         from: cluster.worker.id,

--- a/crawlerService/frontPageCrawler.js
+++ b/crawlerService/frontPageCrawler.js
@@ -43,7 +43,7 @@ module.exports = {
     var count = 0;
 
     var addPosts = (url) => {
-      request(url, (err, res, html) => {
+      request({ url: url, timeout: 10000}, (err, res, html) => {
         if (err) {
           console.log(err);
         } else {
@@ -67,7 +67,7 @@ module.exports = {
       });
     };
     var addPostsSiteMap = (url) => {
-      request(url, (err, res, xml) => {
+      request({ url: url, timeout: 10000}, (err, res, xml) => {
         if (err) {
           console.log(err);
         } else {

--- a/crawlerService/frontPageCrawler.js
+++ b/crawlerService/frontPageCrawler.js
@@ -37,6 +37,8 @@ var isValid = (url) => {
 
 module.exports = {
   getPosts: (urlList, callback) => {
+
+    //Note to Amir: urlList is now identical to whitelist.json
     var result = [];      
     var added = {};
     var filters = ['header', 'footer', 'aside', 'nav', '.nav', '.navbar'];
@@ -91,11 +93,13 @@ module.exports = {
         }
       });
     };
-    urlList.forEach((url) => {
-      if (whiteList[url] && whiteList[url].siteMap) {
-        addPostsSiteMap(whiteList[url].siteMap);
+    urlList.forEach((urlObj) => {
+      //No need to check both if it's in the whitelist now,
+      //just if it has a sitemap
+      if (urlObj.siteMap) {
+        addPostsSiteMap(urlObj.siteMap);
       } else {
-        addPosts(url);
+        addPosts(Object.keys(urlObj)[0]);
       }
     });
   },

--- a/crawlerService/loadWL.js
+++ b/crawlerService/loadWL.js
@@ -1,0 +1,34 @@
+//File to load in the base urls and whitelist urls
+
+var whitelist = require('./whitelist.json');
+var baseUrls = require('./baseUrls.json');
+var db = require('./workerUtils/wlUtils.js');
+
+
+for (var url in whitelist) {
+  console.log(url, whitelist[url]);
+  var obj = {
+    url: url
+  };
+
+  if (whitelist[url].siteMap) {
+    obj.siteMap = whitelist[url].siteMap;
+  }
+
+  console.log(obj);
+
+  db.addOne(obj, (err, created) => console.log(err, created.dataValues));
+  
+}
+
+
+for (var url in baseUrls) {
+  // console.log(url, baseUrls[url]);
+
+  obj = {
+    url: url,
+    base: true
+  };
+
+  db.addOne(obj, (err, created) => console.log(err, created.dataValues));
+}

--- a/crawlerService/loadWL.js
+++ b/crawlerService/loadWL.js
@@ -15,8 +15,6 @@ for (var url in whitelist) {
     obj.siteMap = whitelist[url].siteMap;
   }
 
-  console.log(obj);
-
   db.addOne(obj, (err, created) => console.log(err, created.dataValues));
   
 }

--- a/crawlerService/postCrawler.js
+++ b/crawlerService/postCrawler.js
@@ -17,7 +17,8 @@ prompt.delimiter = colors.green(' <-=-=-=-=-=-> ');
 const badTitles = [
   '',
   ' ',
-  '2011-01'
+  '2011-01',
+  'Page not found · GitHub Pages'
 ];
 
 class PostCrawler {
@@ -27,6 +28,7 @@ class PostCrawler {
     this.parent = options.parent;
     this.$ = null;
     this.interactive = options.interactive;
+    this.baseUrls = options.baseUrls;
 
     this.postInfo = {
       author: null,
@@ -106,8 +108,7 @@ class PostCrawler {
       } else {
         //The normal way when we aren't in interactive mode
         if (!redirectRegEx.test(href) &&
-            // THIS IS WHERE THE CHECK AGAINST THE BASE URLS IS
-            baseUrls[this.getBaseUrl(href)] &&
+            this.baseUrls[this.getBaseUrl(href)] &&
             !urls[href] &&
             this.getBaseUrl(href) !== this.getBaseUrl(this.url)) {
           urls[href] = true;
@@ -178,7 +179,7 @@ class PostCrawler {
     if (authorRel.length > 0) {
       author = authorRel;
     // Check for author tag
-    } else if (authorTag.length > 0) {
+    } else if (authorTag.length > 0 ) {
       author = authorTag;
     }
 
@@ -211,7 +212,7 @@ class PostCrawler {
 
   setDesc() {
     const p =
-      this.$('#content, #main, .post, .entry, .content')
+      this.$('body, #content, #main, .post, .entry, .content')
         .find('p')
         // .first()
         .map(function(i, el) {
@@ -238,6 +239,7 @@ const addEdge = function(cb, options) {
 
       cb(postInfo.links);
 
+      console.log(postInfo.desc, postInfo.title);
       if (postInfo.desc !== '...' && badTitles.indexOf(postInfo.title) < 0) {
         postUtils.createOneWithEdge(postInfo, crawler.parent, (errEdge, found) => {
           if (errEdge) {
@@ -255,6 +257,7 @@ exports.crawlUrl = (options, opt, cb) => {
   console.log('CRAWLING: ', options.url);
   if (opt) {
     options.interactive = opt.interactive;
+    options.baseUrls = opt.baseUrls;
   }
 
   if (options.parent && options.interactive) {
@@ -277,6 +280,8 @@ exports.crawlUrl = (options, opt, cb) => {
       }
       if (result.decision === 'y') {
         //Add it to the whitelist and Q HERE
+
+        //Add it to both the DB and also to the 
         addEdge(cb, options);
       } else {
         console.log(colors.magenta('Not adding it'));

--- a/crawlerService/postCrawler.js
+++ b/crawlerService/postCrawler.js
@@ -206,16 +206,41 @@ class PostCrawler {
     const p =
       this.$('#content, #main, .post, .entry, .content')
         .find('p')
-        .first()
-        .text()
+        // .first()
+        .map(function(i, el) {
+          return cheerio(this).text();
+        })
+        .get()
+        .join(' | ')
         // Remove newline characters and tabs
         .replace(/\r?\n|\r|\t/g, '')
         .trim();
-    this.postInfo.desc = p.slice(0, 97).concat('...');
+    this.postInfo.desc = p.slice(0, 200).concat('...');
   }
 }
 
 exports.PostCrawler = PostCrawler;
+
+const addEdge = function() {
+  const crawler = new PostCrawler(options);
+  crawler.get((errGet, postInfo) => {
+    if (errGet) {
+      console.log(errGet);
+      cb([]);
+    } else {
+
+      cb(postInfo.links);
+
+      postUtils.createOneWithEdge(postInfo, crawler.parent, (errEdge, found) => {
+        if (errEdge) {
+          console.log(errEdge);
+        } else {
+          console.log('STORED: ', found.dataValues.url);
+        }
+      });
+    }
+  });
+};
 
 exports.crawlUrl = (options, opt, cb) => {
   console.log('CRAWLING: ', options.url);

--- a/crawlerService/postCrawler.js
+++ b/crawlerService/postCrawler.js
@@ -38,7 +38,7 @@ class PostCrawler {
     this.parent = options.parent;
     this.$ = null;
     this.interactive = options.interactive;
-    this.baseUrls = options.baseUrls;
+    this.baseUrls = options.baseUrls || {};
     this.baseUrl = null;
 
     this.postInfo = {

--- a/crawlerService/postCrawler.js
+++ b/crawlerService/postCrawler.js
@@ -127,6 +127,7 @@ class PostCrawler {
             this.baseUrls[this.getBaseUrl(href)] &&
             !urls[href] &&
             this.getBaseUrl(href) !== this.getBaseUrl(this.url)) {
+          console.log('HERE-------------------');
           urls[href] = true;
           this.postInfo.links.push({
             parent: this.url,

--- a/crawlerService/postCrawler.js
+++ b/crawlerService/postCrawler.js
@@ -29,6 +29,7 @@ class PostCrawler {
     this.$ = null;
     this.interactive = options.interactive;
     this.baseUrls = options.baseUrls;
+    this.baseUrl = null;
 
     this.postInfo = {
       author: null,
@@ -52,6 +53,7 @@ class PostCrawler {
         this.setAuthor();
         this.setDate();
         this.setDesc();
+        this.setBaseUrl();
 
         cb(null, this.postInfo);
       }
@@ -75,6 +77,10 @@ class PostCrawler {
 
   getLinks() {
     return this.postInfo.links;
+  }
+
+  setBaseUrl() {
+    this.baseUrl = this.getBaseUrl(this.url);
   }
 
   getBaseUrl(url) {
@@ -179,7 +185,7 @@ class PostCrawler {
     if (authorRel.length > 0) {
       author = authorRel;
     // Check for author tag
-    } else if (authorTag.length > 0 ) {
+    } else if (authorTag.length > 0 && authorTag.length < 50) {
       author = authorTag;
     }
 

--- a/crawlerService/postCrawler.js
+++ b/crawlerService/postCrawler.js
@@ -235,6 +235,7 @@ class PostCrawler {
           return cheerio(this).text();
         })
         .get()
+        .filter(text => text.match(/[\S]/))
         .join(' | ')
         // Remove newline characters and tabs
         .replace(/\r?\n|\r|\t/g, '')

--- a/crawlerService/postCrawler.js
+++ b/crawlerService/postCrawler.js
@@ -20,7 +20,7 @@ const baseUrlGetter = (url) => {
   return regex.exec(url)[4] ? null : regex.exec(url)[2];
 };
 
-const sitMapGetter = (url) => {
+const siteMapGetter = (url) => {
   return undefined;
 };
 
@@ -276,14 +276,15 @@ exports.crawlUrl = (options, opt, cb) => {
     options.baseUrls = opt.baseUrls;
   }
 
+
   if (options.parent && options.interactive) {
 
     var properties = [
       {
-        message: 'Url: ' + options.url,
+        message: 'Add this url? ' + options.url,
         name: 'decision', 
-        validator: /^[y|n]+$/,
-        warning: colors.red('Just say yes or no man (y,n)')
+        validator: /^[y|n|e]+$/,
+        warning: colors.red('Just say yes or no or exit man (y,n,e)')
       }
     ];
 
@@ -304,7 +305,7 @@ exports.crawlUrl = (options, opt, cb) => {
         };
 
         var siteMap = siteMapGetter(options.url);
-        
+
         var wlObj = {
           url: options.url
         };
@@ -314,18 +315,24 @@ exports.crawlUrl = (options, opt, cb) => {
         }
 
 
-        wl.addOne(baseObj, (err, saved) => console.log('ADDED TO BASEURLS: ', saved));
-        wl.addOne(wlObj, (err, saved) => console.log('ADDED TO WHITELIST: ', saved));
+        wl.addOne(baseObj, (err, saved) => console.log('ADDED TO BASE_URLS: ', saved.dataValues.url));
+        wl.addOne(wlObj, (err, saved) => console.log('ADDED TO WHITELIST: ', saved.dataValues.url));
 
         //Add to the in-memory objext of baseUrls now too 
         //so the interactive crawler will keep working
         opt.baseUrls[base] = true;
         //Finally, add the post to the DB
         addEdge(cb, options);
-      } else {
+      } else if (result.decision === 'n') {
         console.log(colors.magenta('Not adding it'));
         cb([]);
         return 1;
+      } else {
+        console.log(colors.rainbow('EXITING INTERACTIVE MODE'));
+        
+        //add to in-memory object so the interaction stops
+        opt.interactive = false;
+        cb([]);
       }
     });
 

--- a/crawlerService/postCrawler.js
+++ b/crawlerService/postCrawler.js
@@ -14,6 +14,12 @@ const colors = require('colors/safe');
 prompt.message = colors.underline.green('BlogRank');
 prompt.delimiter = colors.green(' <-=-=-=-=-=-> ');
 
+const badTitles = [
+  '',
+  ' ',
+  '2011-01'
+];
+
 class PostCrawler {
 
   constructor(options) {
@@ -221,7 +227,7 @@ class PostCrawler {
 
 exports.PostCrawler = PostCrawler;
 
-const addEdge = function() {
+const addEdge = function(cb, options) {
   const crawler = new PostCrawler(options);
   crawler.get((errGet, postInfo) => {
     if (errGet) {
@@ -231,13 +237,15 @@ const addEdge = function() {
 
       cb(postInfo.links);
 
-      postUtils.createOneWithEdge(postInfo, crawler.parent, (errEdge, found) => {
-        if (errEdge) {
-          console.log(errEdge);
-        } else {
-          console.log('STORED: ', found.dataValues.url);
-        }
-      });
+      if (postInfo.desc !== '...' && badTitles.indexOf(postInfo.title) < 0) {
+        postUtils.createOneWithEdge(postInfo, crawler.parent, (errEdge, found) => {
+          if (errEdge) {
+            console.log(errEdge);
+          } else {
+            console.log('STORED: ', found.dataValues.url);
+          }
+        });
+      }
     }
   });
 };
@@ -268,24 +276,7 @@ exports.crawlUrl = (options, opt, cb) => {
       }
       if (result.decision === 'y') {
         //Add it to the whitelist and Q
-        const crawler = new PostCrawler(options);
-        crawler.get((errGet, postInfo) => {
-          if (errGet) {
-            console.log(errGet);
-            cb([]);
-          } else {
-
-            cb(postInfo.links);
-
-            postUtils.createOneWithEdge(postInfo, crawler.parent, (errEdge, found) => {
-              if (errEdge) {
-                console.log(errEdge);
-              } else {
-                console.log('STORED: ', found.dataValues.url);
-              }
-            });
-          }
-        });
+        addEdge(cb, options);
       } else {
         console.log(colors.magenta('Not adding it'));
         cb([]);
@@ -295,25 +286,7 @@ exports.crawlUrl = (options, opt, cb) => {
 
   //Not interactive yet
   } else {  
-    const crawler = new PostCrawler(options);
-    crawler.get((errGet, postInfo) => {
-      if (errGet) {
-        console.log(errGet);
-        cb([]);
-      } else {
-
-        cb(postInfo.links);
-
-        postUtils.createOneWithEdge(postInfo, crawler.parent, (errEdge, found) => {
-          if (errEdge) {
-            console.log(errEdge);
-          } else {
-            console.log('STORED: ', found.dataValues.url);
-          }
-        });
-      }
-    });
+    addEdge(cb, options);
   }
-
 };
 

--- a/crawlerService/postCrawler.js
+++ b/crawlerService/postCrawler.js
@@ -106,6 +106,7 @@ class PostCrawler {
       } else {
         //The normal way when we aren't in interactive mode
         if (!redirectRegEx.test(href) &&
+            // THIS IS WHERE THE CHECK AGAINST THE BASE URLS IS
             baseUrls[this.getBaseUrl(href)] &&
             !urls[href] &&
             this.getBaseUrl(href) !== this.getBaseUrl(this.url)) {
@@ -275,7 +276,7 @@ exports.crawlUrl = (options, opt, cb) => {
         return 1;
       }
       if (result.decision === 'y') {
-        //Add it to the whitelist and Q
+        //Add it to the whitelist and Q HERE
         addEdge(cb, options);
       } else {
         console.log(colors.magenta('Not adding it'));

--- a/crawlerService/scheduler.js
+++ b/crawlerService/scheduler.js
@@ -6,7 +6,7 @@ const path = require('path');
 const crawlUrl = require('./postCrawler').crawlUrl;
 
 module.exports = {
-  scheduleCrawlersMulti: (urlList, callback) => {
+  scheduleCrawlersMulti: (urlList, options, callback) => {
     if (cluster.isMaster) {
       cluster.setupMaster({
         exec: path.join(__dirname, 'childProc.js')
@@ -28,7 +28,8 @@ module.exports = {
             type: 'start',
             from: 'master',
             data: urlList[urlCount],
-            count: urlCount
+            count: urlCount,
+            options: options
           });
         } else if (message.type = 'finish') {
           crawled[urlList[message.count].url] = true;
@@ -42,7 +43,8 @@ module.exports = {
               type: 'start',
               from: 'master',
               data: urlList[urlCount],
-              count: urlCount
+              count: urlCount,
+              options: options
             });
           } else {
             cluster.workers[message.from].send({
@@ -122,7 +124,7 @@ module.exports = {
         }
       });
     });
-    
+
     var scheduleCrawlersInteractive = module.exports.scheduleCrawlersInteractive;
     var crawled = crawled || {};
 

--- a/crawlerService/scheduler.js
+++ b/crawlerService/scheduler.js
@@ -117,14 +117,6 @@ module.exports = {
       return;
     }
 
-    ON_DEATH((signal, err) => {
-      fs.writeFile('queue.json', JSON.stringify(urlList.slice(urlCount)), (err) => {
-        if (err) {
-          console.log(err);
-        }
-      });
-    });
-
     var scheduleCrawlersInteractive = module.exports.scheduleCrawlersInteractive;
     var crawled = crawled || {};
 
@@ -132,7 +124,8 @@ module.exports = {
 
     crawlUrl(urlList[tracker], options, (links, index) => {
       
-      console.log('Is the baseUrl list in memory growing? ', Object.keys(options.baseUrls).length);
+      console.log('Your current baseUrl and whitelist size: ', Object.keys(options.baseUrls).length);
+      
       var result = urlList.slice();
 
       if (!crawled[urlList[tracker].url]) {

--- a/crawlerService/scheduler.js
+++ b/crawlerService/scheduler.js
@@ -121,7 +121,9 @@ module.exports = {
 
 
     crawlUrl(urlList[tracker], options, (links, index) => {
+      
       var result = urlList.slice();
+
       if (!crawled[urlList[tracker].url]) {
         crawled[urlList[tracker].url] = true;
         var result = result.concat(links);

--- a/crawlerService/scheduler.js
+++ b/crawlerService/scheduler.js
@@ -132,6 +132,7 @@ module.exports = {
 
     crawlUrl(urlList[tracker], options, (links, index) => {
       
+      console.log('Is the baseUrl list in memory growing? ', Object.keys(options.baseUrls).length);
       var result = urlList.slice();
 
       if (!crawled[urlList[tracker].url]) {

--- a/crawlerService/scheduler.js
+++ b/crawlerService/scheduler.js
@@ -5,6 +5,11 @@ const fs = require('fs');
 const path = require('path');
 const crawlUrl = require('./postCrawler').crawlUrl;
 
+const baseUrlGetter = (url) => {
+  const regex = new RegExp('^(?:([^:/?#]+):)?(?://([^/?#]*))?([^?#]*)(\\?(?:[^#]*))?(#(‌​?:.*))?');
+  return regex.exec(url)[4] ? null : regex.exec(url)[2];
+};
+
 module.exports = {
   scheduleCrawlersMulti: (urlList, options, callback) => {
     if (cluster.isMaster) {
@@ -125,12 +130,18 @@ module.exports = {
     crawlUrl(urlList[tracker], options, (links, index) => {
       
       console.log('Your current baseUrl and whitelist size: ', Object.keys(options.baseUrls).length);
-      
+
       var result = urlList.slice();
 
       if (!crawled[urlList[tracker].url]) {
         crawled[urlList[tracker].url] = true;
-        var result = result.concat(links);
+        console.log(links);
+        //Add these to the beginning of the Q
+        if (links[0] && links[0].parent.match(/www.blogger.com\/profile/)) {
+          result = links.concat(result);
+        } else {
+          result = result.concat(links);
+        }
       }
 
       scheduleCrawlersInteractive(result, options, callback, crawled, tracker + 1);

--- a/crawlerService/scheduler.js
+++ b/crawlerService/scheduler.js
@@ -115,6 +115,14 @@ module.exports = {
       return;
     }
 
+    ON_DEATH((signal, err) => {
+      fs.writeFile('queue.json', JSON.stringify(urlList.slice(urlCount)), (err) => {
+        if (err) {
+          console.log(err);
+        }
+      });
+    });
+    
     var scheduleCrawlersInteractive = module.exports.scheduleCrawlersInteractive;
     var crawled = crawled || {};
 

--- a/crawlerService/scheduler.js
+++ b/crawlerService/scheduler.js
@@ -148,7 +148,6 @@ module.exports = {
           //Add these to the beginning of the Q
           if (links[0] && links[0].parent.match(/www.blogger.com\/profile/)) {
             result = links.concat(result);
-            console.log(result.slice(0, 3));
           } else {
             result = result.concat(links);
           }

--- a/crawlerService/startCrawlers.js
+++ b/crawlerService/startCrawlers.js
@@ -45,8 +45,12 @@ const start = () => {
 
       if (process.argv.indexOf('--continue') > -1) {
         const queue = require('./queue.json');
+        
+        var options = {
+          baseUrls: base
+        };
 
-        scheduler.scheduleCrawlersMulti(queue, (time) => {
+        scheduler.scheduleCrawlersMulti(queue, options, (time) => {
           console.log(time - startTime);
         });
       } else if (process.argv.indexOf('--add') > -1) {
@@ -68,20 +72,18 @@ const start = () => {
             return 1;
           }
           if (result.decision === 'y') {
-            console.log(colors.rainbow('\nYoU jUsT eNtErEd InTeRaCtIvE mOdE!!@@#$!!!'));
+            console.log(colors.rainbow('\nYOU JUST ENTERED INTERACTIVE MODE~~~~~'));
             console.log('Getting some random front page posts');
 
             randomSites = [];
 
-            for (var i = 0; i < 1; i++) {
+            for (var i = 0; i < 2; i++) {
               var randomSite = whiteListKeys[Math.floor(Math.random() * whiteListKeys.length)];
               var randomSiteObj = whitelist[randomSite];
               if (randomSites.indexOf(randomSiteObj) < 0) {
                 randomSites.push(randomSiteObj);
               }
             }
-
-            console.log(randomKeys);
 
             frontPageCrawler.getPosts(randomSites, (results) => {
 

--- a/crawlerService/startCrawlers.js
+++ b/crawlerService/startCrawlers.js
@@ -1,8 +1,6 @@
 const frontPageCrawler = require('./frontPageCrawler');
 const crawlUrl = require('./postCrawler').crawlUrl;
 const scheduler = require('./scheduler');
-const whitelist = require('./whitelist.json');
-
 const wl = require('./workerUtils/wlUtils.js');
 
 const prompt = require('prompt');
@@ -11,7 +9,6 @@ prompt.message = colors.underline.green('BlogRank');
 prompt.delimiter = colors.green(' <-=-=-=-=-=-> ');
 
 
-const whiteListKeys = Object.keys(whitelist);
 const startTime = new Date();
 
 const start = () => {
@@ -39,14 +36,13 @@ const start = () => {
                     return obj;
                   });
 
-      console.log(base, whitelist);
-
+      var whiteListKeys = Object.keys(whitelist);
       //First load up whitelist from DB, and pass them down
       //Where are these things checked from the json files?
         //1. front page crawler checks whether theres a sitemap or not
         //2. post crawler checks against base urls, but not in interactive mode
           // --> I think the easiest solution is to give the baseurl list as a reference to each crawler instance
-          
+
       if (process.argv.indexOf('--continue') > -1) {
         const queue = require('./queue.json');
 
@@ -75,17 +71,19 @@ const start = () => {
             console.log(colors.rainbow('\nYoU jUsT eNtErEd InTeRaCtIvE mOdE!!@@#$!!!'));
             console.log('Getting some random front page posts');
 
-            randomKeys = [];
+            randomSites = [];
+
             for (var i = 0; i < 1; i++) {
               var randomSite = whiteListKeys[Math.floor(Math.random() * whiteListKeys.length)];
-              if (randomKeys.indexOf(randomSite) < 0) {
-                randomKeys.push(randomSite);
+              var randomSiteObj = whitelist[randomSite];
+              if (randomSites.indexOf(randomSiteObj) < 0) {
+                randomSites.push(randomSiteObj);
               }
             }
 
             console.log(randomKeys);
 
-            frontPageCrawler.getPosts(randomKeys, (results) => {
+            frontPageCrawler.getPosts(randomSites, (results) => {
 
               console.log('POSTS FROM FRONT PAGE:' + results.length);
               results = results.map(result => {
@@ -95,19 +93,19 @@ const start = () => {
                 };
               });
               scheduler.scheduleCrawlersInteractive(results, {interactive: true}, (time) => {
-                console.log('You just did this for ' + (new Date() - startTime / (60 * 1000)) + ' minutes');
+                console.log('You just did this for ' + ((new Date() - startTime) / (60 * 1000)) + ' minutes');
               });
 
             });
 
           } else {
-            console.log(colors.magenta('Nevermind >:('));
+            console.log(colors.red('Nevermind >:('));
             return 1;
           }
         });
 
       } else {
-        frontPageCrawler.getPosts(whiteListKeys, (results) => {
+        frontPageCrawler.getPosts(whitelist, (results) => {
           console.log('FRONT PAGE POSTS: ', results.length);
           frontPageCrawler.filterPosts(results, (filtered) => {
             console.log('FILTERED POSTS: ', filtered.length);

--- a/crawlerService/startCrawlers.js
+++ b/crawlerService/startCrawlers.js
@@ -32,7 +32,6 @@ const start = () => {
           badUrls[item.url] = true;
         });
 
-
       var whitelist = allLists
                   .filter(item => !item.base)
                   .map(item => {
@@ -44,11 +43,6 @@ const start = () => {
                   });
 
       var whiteListKeys = Object.keys(whitelist);
-      //First load up whitelist from DB, and pass them down
-      //Where are these things checked from the json files?
-        //1. front page crawler checks whether theres a sitemap or not
-        //2. post crawler checks against base urls, but not in interactive mode
-          // --> I think the easiest solution is to give the baseurl list as a reference to each crawler instance
 
       if (process.argv.indexOf('--continue') > -1) {
         const queue = require('./queue.json');
@@ -84,15 +78,17 @@ const start = () => {
 
             randomSites = [];
 
-            for (var i = 0; i < 2; i++) {
-              var randomSite = whiteListKeys[Math.floor(Math.random() * whiteListKeys.length)];
-              var randomSiteObj = whitelist[randomSite];
-              if (randomSites.indexOf(randomSiteObj) < 0) {
-                randomSites.push(randomSiteObj);
-              }
-            }
+            // for (var i = 0; i < 2; i++) {
+            //   var randomSite = whiteListKeys[Math.floor(Math.random() * whiteListKeys.length)];
+            //   var randomSiteObj = whitelist[randomSite];
+            //   if (randomSites.indexOf(randomSiteObj) < 0) {
+            //     randomSites.push(randomSiteObj);
+            //   }
+            // }
+            //this is for debugging the blogger.com behavior
+            var neo = whitelist.filter(entry => entry['http://neopythonic.blogspot.com/']);
 
-            frontPageCrawler.getPosts(randomSites, (results) => {
+            frontPageCrawler.getPosts(neo, (results) => {
 
               console.log('POSTS FROM FRONT PAGE:' + results.length);
               results = results.map(result => {
@@ -104,7 +100,8 @@ const start = () => {
 
               var options = {
                 interactive: true,
-                baseUrls: base
+                baseUrls: base,
+                badUrls: badUrls
               };
 
               scheduler.scheduleCrawlersInteractive(results, options, (time) => {

--- a/crawlerService/startCrawlers.js
+++ b/crawlerService/startCrawlers.js
@@ -78,17 +78,15 @@ const start = () => {
 
             randomSites = [];
 
-            // for (var i = 0; i < 2; i++) {
-            //   var randomSite = whiteListKeys[Math.floor(Math.random() * whiteListKeys.length)];
-            //   var randomSiteObj = whitelist[randomSite];
-            //   if (randomSites.indexOf(randomSiteObj) < 0) {
-            //     randomSites.push(randomSiteObj);
-            //   }
-            // }
-            //this is for debugging the blogger.com behavior
-            var neo = whitelist.filter(entry => entry['http://neopythonic.blogspot.com/']);
+            for (var i = 0; i < 2; i++) {
+              var randomSite = whiteListKeys[Math.floor(Math.random() * whiteListKeys.length)];
+              var randomSiteObj = whitelist[randomSite];
+              if (randomSites.indexOf(randomSiteObj) < 0) {
+                randomSites.push(randomSiteObj);
+              }
+            }
 
-            frontPageCrawler.getPosts(neo, (results) => {
+            frontPageCrawler.getPosts(randomSites, (results) => {
 
               console.log('POSTS FROM FRONT PAGE:' + results.length);
               results = results.map(result => {

--- a/crawlerService/startCrawlers.js
+++ b/crawlerService/startCrawlers.js
@@ -13,20 +13,27 @@ const startTime = new Date();
 
 const start = () => {
 
-  wl.findAll((err, bothLists) => {
+  wl.findAll((err, allLists) => {
 
     if (!err) {
 
-      //process list
-      var base = bothLists
-                  .filter(item => item.base)
-                  .map(item => {
-                    var obj = {};
-                    obj[item.url] = true;
-                    return obj;
-                  });
+      //process lists
+      var base = {};
+      allLists
+        .filter(item => item.base)
+        .forEach(item => {
+          base[item.url] = true;
+        });
 
-      var whitelist = bothLists
+      var badUrls = {};
+      allLists
+        .filter(item => item.bad)
+        .forEach(item => {
+          badUrls[item.url] = true;
+        });
+
+
+      var whitelist = allLists
                   .filter(item => !item.base)
                   .map(item => {
                     var obj = {};

--- a/crawlerService/startCrawlers.js
+++ b/crawlerService/startCrawlers.js
@@ -2,6 +2,9 @@ const frontPageCrawler = require('./frontPageCrawler');
 const crawlUrl = require('./postCrawler').crawlUrl;
 const scheduler = require('./scheduler');
 const whitelist = require('./whitelist.json');
+
+const wl = require('./workerUtils/wlUtils.js');
+
 const prompt = require('prompt');
 const colors = require('colors/safe');
 prompt.message = colors.underline.green('BlogRank');
@@ -12,80 +15,118 @@ const whiteListKeys = Object.keys(whitelist);
 const startTime = new Date();
 
 const start = () => {
-  if (process.argv.indexOf('--continue') > -1) {
-    const queue = require('./queue.json');
 
-    scheduler.scheduleCrawlersMulti(queue, (time) => {
-      console.log(time - startTime);
-    });
-  } else if (process.argv.indexOf('--add') > -1) {
+  wl.findAll((err, bothLists) => {
 
-    var properties = [
-      {
-        message: 'ENTER INTERACTIVE MODE? (Y/n)',
-        name: 'decision', 
-        validator: /^[y|n]+$/,
-        warning: colors.red('Just say yes or no man (y,n)')
-      }
-    ];
+    if (!err) {
 
-    prompt.start();
+      //process list
+      var base = bothLists
+                  .filter(item => item.base)
+                  .map(item => {
+                    var obj = {};
+                    obj[item.url] = true;
+                    return obj;
+                  });
 
-    prompt.get(properties, function (err, result) {
-      if (err) { 
-        console.log(err);
-        return 1;
-      }
-      if (result.decision === 'y') {
-        console.log(colors.rainbow('\nYoU jUsT eNtErEd InTeRaCtIvE mOdE!!@@#$!!!'));
-        console.log('Getting some random front page posts');
+      var whitelist = bothLists
+                  .filter(item => !item.base)
+                  .map(item => {
+                    var obj = {};
+                    obj[item.url] = {
+                      siteMap: item.siteMap
+                    };
+                    return obj;
+                  });
 
-        randomKeys = [];
-        for (var i = 0; i < 1; i++) {
-          var randomSite = whiteListKeys[Math.floor(Math.random() * whiteListKeys.length)];
-          if (randomKeys.indexOf(randomSite) < 0) {
-            randomKeys.push(randomSite);
+      console.log(base, whitelist);
+
+      //First load up whitelist from DB, and pass them down
+      //Where are these things checked from the json files?
+        //1. front page crawler checks whether theres a sitemap or not
+        //2. post crawler checks against base urls, but not in interactive mode
+          // --> I think the easiest solution is to give the baseurl list as a reference to each crawler instance
+          
+      if (process.argv.indexOf('--continue') > -1) {
+        const queue = require('./queue.json');
+
+        scheduler.scheduleCrawlersMulti(queue, (time) => {
+          console.log(time - startTime);
+        });
+      } else if (process.argv.indexOf('--add') > -1) {
+
+        var properties = [
+          {
+            message: 'ENTER INTERACTIVE MODE? (Y/n)',
+            name: 'decision', 
+            validator: /^[y|n]+$/,
+            warning: colors.red('Just say yes or no man (y,n)')
           }
-        }
+        ];
 
-        console.log(randomKeys);
+        prompt.start();
 
-        frontPageCrawler.getPosts(randomKeys, (results) => {
+        prompt.get(properties, function (err, result) {
+          if (err) { 
+            console.log(err);
+            return 1;
+          }
+          if (result.decision === 'y') {
+            console.log(colors.rainbow('\nYoU jUsT eNtErEd InTeRaCtIvE mOdE!!@@#$!!!'));
+            console.log('Getting some random front page posts');
 
-          console.log('POSTS FROM FRONT PAGE:' + results.length);
-          results = results.map(result => {
-            return {
-              url: result,
-              parent: null
-            };
-          });
-          scheduler.scheduleCrawlersInteractive(results, {interactive: true}, (time) => {
-            console.log('You just did this for ' + (new Date() - startTime / (60 * 1000)) + ' minutes');
-          });
+            randomKeys = [];
+            for (var i = 0; i < 1; i++) {
+              var randomSite = whiteListKeys[Math.floor(Math.random() * whiteListKeys.length)];
+              if (randomKeys.indexOf(randomSite) < 0) {
+                randomKeys.push(randomSite);
+              }
+            }
 
+            console.log(randomKeys);
+
+            frontPageCrawler.getPosts(randomKeys, (results) => {
+
+              console.log('POSTS FROM FRONT PAGE:' + results.length);
+              results = results.map(result => {
+                return {
+                  url: result,
+                  parent: null
+                };
+              });
+              scheduler.scheduleCrawlersInteractive(results, {interactive: true}, (time) => {
+                console.log('You just did this for ' + (new Date() - startTime / (60 * 1000)) + ' minutes');
+              });
+
+            });
+
+          } else {
+            console.log(colors.magenta('Nevermind >:('));
+            return 1;
+          }
         });
 
       } else {
-        console.log(colors.magenta('Nevermind >:('));
-        return 1;
-      }
-    });
-
-  } else {
-    frontPageCrawler.getPosts(whiteListKeys, (results) => {
-      console.log('FRONT PAGE POSTS: ', results.length);
-      frontPageCrawler.filterPosts(results, (filtered) => {
-        console.log('FILTERED POSTS: ', filtered.length);
-        // scheduler.scheduleCrawlers(filtered, null, (time) => {
-        //   console.log(time - startTime);
-        // });
-        scheduler.scheduleCrawlersMulti(filtered, (time) => {
-          console.log(time - startTime);
+        frontPageCrawler.getPosts(whiteListKeys, (results) => {
+          console.log('FRONT PAGE POSTS: ', results.length);
+          frontPageCrawler.filterPosts(results, (filtered) => {
+            console.log('FILTERED POSTS: ', filtered.length);
+            // scheduler.scheduleCrawlers(filtered, null, (time) => {
+            //   console.log(time - startTime);
+            // });
+            scheduler.scheduleCrawlersMulti(filtered, (time) => {
+              console.log(time - startTime);
+            });
+          });
         });
-      });
-    });
-  }
+      }
+    } else {
+      console.log(err);
+    }
+
+  });
 };
+
 start();
 module.exports = start;
 

--- a/crawlerService/startCrawlers.js
+++ b/crawlerService/startCrawlers.js
@@ -92,7 +92,13 @@ const start = () => {
                   parent: null
                 };
               });
-              scheduler.scheduleCrawlersInteractive(results, {interactive: true}, (time) => {
+
+              var options = {
+                interactive: true,
+                baseUrls: base
+              };
+
+              scheduler.scheduleCrawlersInteractive(results, options, (time) => {
                 console.log('You just did this for ' + ((new Date() - startTime) / (60 * 1000)) + ' minutes');
               });
 
@@ -109,10 +115,15 @@ const start = () => {
           console.log('FRONT PAGE POSTS: ', results.length);
           frontPageCrawler.filterPosts(results, (filtered) => {
             console.log('FILTERED POSTS: ', filtered.length);
-            // scheduler.scheduleCrawlers(filtered, null, (time) => {
+
+            var options = {
+              baseUrls: base
+            };
+
+            // scheduler.scheduleCrawlers(filtered, options, (time) => {
             //   console.log(time - startTime);
             // });
-            scheduler.scheduleCrawlersMulti(filtered, (time) => {
+            scheduler.scheduleCrawlersMulti(filtered, options, (time) => {
               console.log(time - startTime);
             });
           });

--- a/crawlerService/workerUtils/wlUtils.js
+++ b/crawlerService/workerUtils/wlUtils.js
@@ -12,18 +12,17 @@ exports.findAll = function(cb) {
 
 };
 
-exports.addOne = function(urlString, cb) {
+exports.addOne = function(obj, cb) {
   
+  //Url should have properties url, base, and sitemap (if applicable)
   WL.findOne({
     where: {
-      url: urlString,
+      url: obj.url,
     }
   }).then(function(found) {
     // console.log('I found a post: ', found);
     if (!found) {
-      return WL.create({
-        url: urlString
-      });
+      return WL.create(obj);
     } else {
       cb(null, found);      
     }

--- a/db/database.js
+++ b/db/database.js
@@ -105,6 +105,10 @@ exports.WL = sequelize.define('whitelist', {
     type: Sequelize.BOOLEAN,
     default: false
   },
+  bad: {
+    type: Sequelize.BOOLEAN,
+    default: false
+  },
   siteMap: Sequelize.STRING
 });
 

--- a/db/database.js
+++ b/db/database.js
@@ -100,7 +100,12 @@ exports.WL = sequelize.define('whitelist', {
   url: {
     type: Sequelize.STRING,
     unique: true
-  }
+  },
+  base: {
+    type: Sequelize.BOOLEAN,
+    default: false
+  },
+  siteMap: Sequelize.STRING
 });
 
 

--- a/indexService/main.js
+++ b/indexService/main.js
@@ -3,6 +3,8 @@
 //Useful SQL queries
 //select count(*) from posts;
 //select "inLinks", title, url  from posts where array_length("inLinks",1) > 0 order by array_length("inLinks",1) desc;
+//select * from whitelists where url like '%dailywtf%';
+
 
 var db = require('../db/database');
 var Post = db.Post;

--- a/test/unit/utilsTests.js
+++ b/test/unit/utilsTests.js
@@ -198,7 +198,7 @@ describe('Utilities', function() {
 
       var addOne = Promise.promisify(wlUtil.addOne);
 
-      Promise.all(frontPages.map(page => addOne(page))).then(function(saved) {
+      Promise.all(frontPages.map(page => addOne({url: page}))).then(function(saved) {
         //console.log('Resolved: ', stuff);
 
         expect(saved.map(page => page.url)).to.deep.equal(frontPages);
@@ -212,6 +212,7 @@ describe('Utilities', function() {
     it('should get all entries', function(done) {
 
       wlUtil.findAll(function(err, results) {
+        console.log(err);
         expect(results.length).to.equal(4);
         if (!err) {
           done();


### PR DESCRIPTION
A lot of stuff here:
- Improving data fields description and author
- Not adding an edge to the DB if description or title not properly set (most likely these are not blog posts)

Heavily refactor interactivity and crawler service for several things:
- Loading up whitelist from DB on initialization and using these cached objects for both baseUrls and whitelist urls (previously JSON files were used)
- Interactivity now has four options, y to add, no to not add, e to exit interactivity and resume crawling normally, and a for add this baseUrl to the bad urls
- bad urls are persisted and are used to not show matching base urls in interactive mode (we don't need to see every twitter link to decide if it's a blog post)
- when an authors page from blogger.com is detected we put its links in the front of the queue because they are likely good blogs to try
